### PR TITLE
Fixed options in Plyr.svelte, so passed in options are used

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,115 +1,95 @@
 <script>
-  import { Plyr } from './components/components.module.js';
+	import { Plyr } from './components/components.module.js';
 
-  let events = ['timeupdate']
+	let events = ['timeupdate'];
 
-  function logEvent(event) {
-    console.log(event)
-  }
+	function logEvent(event) {
+		console.log(event);
+	}
 </script>
 
 <style>
+
 </style>
 
 <h1>Video Player</h1>
 <Plyr on:timeupdate={logEvent} eventsToEmit={events}>
-  <video
-    crossorigin
-    playsinline
-    poster="https://cdn.plyr.io/static/demo/View_From_A_Blue_Moon_Trailer-HD.jpg"
-    src="https://cdn.plyr.io/static/demo/View_From_A_Blue_Moon_Trailer-576p.mp4"
-  >
-    <source
-      size="576"
-      src="https://cdn.plyr.io/static/demo/View_From_A_Blue_Moon_Trailer-576p.mp4"
-      type="video/mp4"
-    >
-    <source
-      size="720"
-      src="https://cdn.plyr.io/static/demo/View_From_A_Blue_Moon_Trailer-720p.mp4"
-      type="video/mp4"
-    >
-    <source
-      size="1080"
-      src="https://cdn.plyr.io/static/demo/View_From_A_Blue_Moon_Trailer-1080p.mp4"
-      type="video/mp4"
-    >
-    <track
-      default
-      kind="captions"
-      label="English"
-      src="https://cdn.plyr.io/static/demo/View_From_A_Blue_Moon_Trailer-HD.en.vtt"
-      srclang="en"
-    >
-    <track
-      kind="captions"
-      label="Français"
-      src="https://cdn.plyr.io/static/demo/View_From_A_Blue_Moon_Trailer-HD.fr.vtt"
-      srclang="fr"
-    >
-    <a
-      download=""
-      href="https://cdn.plyr.io/static/demo/View_From_A_Blue_Moon_Trailer-576p.mp4"
-    >
-      Download
-    </a>
-  </video>
+	<video
+		crossorigin
+		playsinline
+		poster="https://cdn.plyr.io/static/demo/View_From_A_Blue_Moon_Trailer-HD.jpg"
+		src="https://cdn.plyr.io/static/demo/View_From_A_Blue_Moon_Trailer-576p.mp4">
+		<source
+			size="576"
+			src="https://cdn.plyr.io/static/demo/View_From_A_Blue_Moon_Trailer-576p.mp4"
+			type="video/mp4" />
+		<source
+			size="720"
+			src="https://cdn.plyr.io/static/demo/View_From_A_Blue_Moon_Trailer-720p.mp4"
+			type="video/mp4" />
+		<source
+			size="1080"
+			src="https://cdn.plyr.io/static/demo/View_From_A_Blue_Moon_Trailer-1080p.mp4"
+			type="video/mp4" />
+		<track
+			default
+			kind="captions"
+			label="English"
+			src="https://cdn.plyr.io/static/demo/View_From_A_Blue_Moon_Trailer-HD.en.vtt"
+			srclang="en" />
+		<track
+			kind="captions"
+			label="Français"
+			src="https://cdn.plyr.io/static/demo/View_From_A_Blue_Moon_Trailer-HD.fr.vtt"
+			srclang="fr" />
+		<a
+			download=""
+			href="https://cdn.plyr.io/static/demo/View_From_A_Blue_Moon_Trailer-576p.mp4">
+			Download
+		</a>
+	</video>
 </Plyr>
 
 <h1>Audio Player</h1>
 <Plyr>
-  <audio
-    crossorigin
-    playsinline
-  >
-    <source
-      src="https://cdn.plyr.io/static/demo/Kishi_Bashi_-_It_All_Began_With_a_Burst.mp3"
-      type="audio/mp3"
-    >
-    <source
-      src="https://cdn.plyr.io/static/demo/Kishi_Bashi_-_It_All_Began_With_a_Burst.ogg"
-      type="audio/ogg"
-      >
-  </audio>
+	<audio crossorigin playsinline>
+		<source
+			src="https://cdn.plyr.io/static/demo/Kishi_Bashi_-_It_All_Began_With_a_Burst.mp3"
+			type="audio/mp3" />
+		<source
+			src="https://cdn.plyr.io/static/demo/Kishi_Bashi_-_It_All_Began_With_a_Burst.ogg"
+			type="audio/ogg" />
+	</audio>
 </Plyr>
 
 <h1>YouTube</h1>
 <Plyr>
-  <div class="plyr__video-embed">
-    <iframe
-      allow="autoplay"
-      allowfullscreen
-      allowtransparency
-      src="https://www.youtube.com/embed/bTqVqk7FSmY?iv_load_policy=3&modestbranding=1&playsinline=1&showinfo=0&rel=0&enablejsapi=1"
-    />
-  </div>
+	<div class="plyr__video-embed">
+		<iframe
+			allow="autoplay"
+			allowfullscreen
+			allowtransparency
+			src="https://www.youtube.com/embed/bTqVqk7FSmY?iv_load_policy=3&modestbranding=1&playsinline=1&showinfo=0&rel=0&enablejsapi=1" />
+	</div>
 </Plyr>
 
 <h1>Vimeo</h1>
 <Plyr>
-  <div class="plyr__video-embed">
-    <iframe
-      allow="autoplay"
-      allowfullscreen
-      allowtransparency
-      src="https://player.vimeo.com/video/76979871?loop=false&byline=false&portrait=false&title=false&speed=true&transparent=0&gesture=media"
-    />
-  </div>
+	<div class="plyr__video-embed">
+		<iframe
+			allow="autoplay"
+			allowfullscreen
+			allowtransparency
+			src="https://player.vimeo.com/video/76979871?loop=false&byline=false&portrait=false&title=false&speed=true&transparent=0&gesture=media" />
+	</div>
 </Plyr>
 
 <h1>YouTube (Not Progressive Enhancement)</h1>
 <Plyr>
-  <div
-    data-plyr-embed-id="bTqVqk7FSmY"
-    data-plyr-provider="youtube"
-  />
+	<div data-plyr-embed-id="bTqVqk7FSmY" data-plyr-provider="youtube" />
 </Plyr>
 
 <h1>Vimeo (Not Progressive Enhancement)</h1>
 <Plyr>
-  <div
-    data-plyr-embed-id="76979871"
-    data-plyr-provider="vimeo"
-  />
+	<div data-plyr-embed-id="76979871" data-plyr-provider="vimeo" />
 </Plyr>
-

--- a/src/components/Plyr.svelte
+++ b/src/components/Plyr.svelte
@@ -1,46 +1,50 @@
 <script>
-  import { onMount, onDestroy, createEventDispatcher } from 'svelte';
-  import Plyr from 'plyr'
-  import '../plyr.scss'
+	import { onMount, onDestroy, createEventDispatcher } from 'svelte';
+	import Plyr from 'plyr';
+	import '../plyr.scss';
 
-  export let eventsToEmit = []
-  export let options = {}
-  export let player = {}
-  let plyrDiv
-  const dispatch = createEventDispatcher();
+	export let eventsToEmit = [];
+	export let options = {};
+	export let player = {};
+	let plyrDiv;
+	const dispatch = createEventDispatcher();
 
-  $: opts()
+	$: opts();
 
-  function opts () {
-    if (!options.hasOwnProperty('hideYouTubeDOMError')) {
-      options.hideYouTubeDOMError = true
-    }
-    return options
-  }
+	function opts() {
+		if (!options.hasOwnProperty('hideYouTubeDOMError')) {
+			options.hideYouTubeDOMError = true;
+		}
+		return options;
+	}
 
-  onMount(async () => {
-    player = new Plyr(plyrDiv.firstChild, opts)
-    eventsToEmit.forEach(event => dispatchOnPlayerEvent(event))
-  })
+	onMount(async () => {
+		player = new Plyr(plyrDiv.firstChild, options);
+		eventsToEmit.forEach((event) => dispatchOnPlayerEvent(event));
+	});
 
-  onDestroy(() => {
-    try {
-      player.destroy()
-    } catch (e) {
-      if (!(opts.hideYouTubeDOMError && e.message === 'The YouTube player is not attached to the DOM.')) {
-        // eslint-disable-next-line no-console
-        console.error(e)
-      }
-    }
-  })
+	onDestroy(() => {
+		try {
+			player.destroy();
+		} catch (e) {
+			if (
+				!(
+					options.hideYouTubeDOMError &&
+					e.message ===
+						'The YouTube player is not attached to the DOM.'
+				)
+			) {
+				// eslint-disable-next-line no-console
+				console.error(e);
+			}
+		}
+	});
 
-  function dispatchOnPlayerEvent (event) {
-    player.on(event, data => dispatch(event, data.detail.plyr))
-  }
+	function dispatchOnPlayerEvent(event) {
+		player.on(event, (data) => dispatch(event, data.detail.plyr));
+	}
 </script>
 
 <div bind:this={plyrDiv}>
-  <slot></slot>
+	<slot />
 </div>
-
-

--- a/src/plyr.scss
+++ b/src/plyr.scss
@@ -1,3 +1,3 @@
 @charset "utf-8";
 
-@import "~plyr/src/sass/plyr.scss"
+@import "~plyr/src/sass/plyr.scss";


### PR DESCRIPTION
The passed in options to <Plyr> are not used. This is because you are not passing the options object to the plyr class but rather the opts() function which adds properties to the options object. Alternatively you could also replace the formerly used opts with opts(). I just think it is more meaningful to actually pass in the options object.

P.S.: I reworked as little as needed to get it working for me. But I could see this code getting a lot neater by replacing
```javascript 
$: opts();

function opts() {
	if (!options.hasOwnProperty('hideYouTubeDOMError')) {
		options.hideYouTubeDOMError = true;
	}
	return options;
}```
with
```javascript 
$: {
	if (!options.hasOwnProperty('hideYouTubeDOMError')) {
		options.hideYouTubeDOMError = true;
	}
}```

